### PR TITLE
Fixed sed command if api icon is not presented

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -9,7 +9,7 @@ fi
 if [ -n "$API_FAVICON" ]; then
   sed -i "s|%API_FAVICON%|<link rel=\"icon\" href=\"$API_FAVICON\">|g" /usr/share/nginx/html/index.html
 else
-  sed -i "|%API_FAVICON%|d" /usr/share/nginx/html/index.html
+  sed -i "/%API_FAVICON%/d" /usr/share/nginx/html/index.html
 fi
 
 if [ -n "$API_URL" ]; then


### PR DESCRIPTION
https://www.gnu.org/software/sed/manual/sed.html#The-_0022s_0022-Command
Seems like custom separators are allowed only for `s` command.
It was failing for me on Ubuntu if `API_FAVICON` wasn't set. Could you please check it on Mac?