### PR TITLE
Made redoc script src relative

### DIFF
--- a/config/docker/index.tpl.html
+++ b/config/docker/index.tpl.html
@@ -20,7 +20,7 @@
 
 <body>
   <redoc spec-url="%SPEC_URL%" %REDOC_OPTIONS%></redoc>
-  <script src="/redoc.standalone.js"></script>
+  <script src="redoc.standalone.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Right now we have hack in cf-worker to handle it.
But we can just make it relative so it would load `/docs/redoc.standalone.js` from the `/docs/` page.
Note: it should be deployed only after the hack would be removed from `cf-worker`